### PR TITLE
Fixed typo: `componant` -> `component`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -345,7 +345,7 @@
 				</h3>
 				<p>
 					You want to display a checkbox, i.e. a box with a checkmark that appears on click on this box.
-					Even if you should use the <code class="language-html">&lt;input type="checkbox"&gt;</code> native componant, in some case, you can’t.
+					Even if you should use the <code class="language-html">&lt;input type="checkbox"&gt;</code> native component, in some case, you can’t.
 				</p>
 				<section>
 					<h4 id="simple-checkbox">
@@ -467,7 +467,7 @@
 				</h3>
 				<p>
 					You want to display some radio buttons, i.e. somes boxes with a checkmark that appears on click on these boxes, only one at a time.
-					Even if you should use the <code class="language-html">&lt;input type="radio"&gt;</code> native componant, in some case, you can’t.
+					Even if you should use the <code class="language-html">&lt;input type="radio"&gt;</code> native component, in some case, you can’t.
 				</p>
 				<section>
 					<h4 id="simple-radio">


### PR DESCRIPTION
Noticed a small typo in the docs: I think [componant](https://en.wiktionary.org/wiki/componant) should be [component](https://en.wiktionary.org/wiki/component) instead.